### PR TITLE
[ci/cd] QueryDSL 코드 생성 도구를 KSP에서 KAPT로 전환

### DIFF
--- a/.claude/skills/pr-draft/references/labels.md
+++ b/.claude/skills/pr-draft/references/labels.md
@@ -5,12 +5,12 @@ Select **1 Type label** for PRs.
 ## Type Labels (pick 1)
 
 | Label | Description | When to use |
-|-------|-------------|-------------|
-| `Type: Feature/Function` | 새로운 기능 및 개선 사항 | New feature, improvement, refactoring |
-| `Type: Feature/Document` | 문서 추가 및 보완 작업 | Docs, README, skill files, comments |
-| `Type: Bug/Function` | 정상 동작하지 않는 기능 | Functional bug fix |
-| `Type: Release` | 릴리즈 | Release preparation, version bump |
-| `Setting` | 환경 세팅 | Environment config, build, CI/CD |
+|----|-------------|-------------|
+| `📩 Type: Feature/Function` | 새로운 기능 및 개선 사항 | New feature, improvement, refactoring |
+| `📜 Type: Feature/Document` | 문서 추가 및 보완 작업 | Docs, README, skill files, comments |
+| `🐞 Type: Bug/Function` | 정상 동작하지 않는 기능 | Functional bug fix |
+| `🪽 Type: Release` | 릴리즈 | Release preparation, version bump |
+| `⚙ Setting` | 환경 세팅 | Environment config, build, CI/CD |
 
 ## Off-limits Labels (do NOT assign)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.spring") version "2.3.20"
     kotlin("plugin.jpa") version "2.3.20"
-    id("com.google.devtools.ksp") version "2.3.6"
+    kotlin("kapt") version "2.3.20"
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
@@ -33,10 +33,10 @@ dependencies {
     implementation(Libs.KOTLIN_REFLECT)
     implementation(Libs.QUERYDSL_JPA)
 
-    ksp(Libs.QUERYDSL_KSP_CODEGEN)
+    kapt(Libs.QUERYDSL_KAPT)
 
     compileOnly(Libs.LOMBOK)
-    annotationProcessor(Libs.LOMBOK)
+    kapt(Libs.LOMBOK)
 
     runtimeOnly(Libs.MYSQL_CONNECTOR)
 
@@ -45,7 +45,8 @@ dependencies {
     testImplementation(Libs.SPRING_GRAPHQL_TEST)
     testImplementation(Libs.SPRING_SECURITY_TEST)
     testCompileOnly(Libs.LOMBOK)
-    testAnnotationProcessor(Libs.LOMBOK)
+    kaptTest(Libs.LOMBOK)
+
     testRuntimeOnly(Libs.JUNIT_PLATFORM_LAUNCHER)
 }
 
@@ -59,6 +60,10 @@ ktlint {
     version.set("1.5.0")
 }
 
+kapt {
+    correctErrorTypes = true
+}
+
 allOpen {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.MappedSuperclass")
@@ -67,4 +72,12 @@ allOpen {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs("build/generated/source/kapt/main")
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,10 +74,8 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs("build/generated/source/kapt/main")
-        }
+ktlint {
+    filter {
+        exclude("**/generated/**")
     }
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -16,9 +16,9 @@ object Libs {
     // Database
     const val MYSQL_CONNECTOR = "com.mysql:mysql-connector-j"
 
-    //QueryDSL
+    // QueryDSL
     const val QUERYDSL_JPA = "io.github.openfeign.querydsl:querydsl-jpa:6.10.1"
-    const val QUERYDSL_KSP_CODEGEN = "io.github.openfeign.querydsl:querydsl-ksp-codegen:6.10.1"
+    const val QUERYDSL_KAPT = "io.github.openfeign.querydsl:querydsl-apt:6.10.1:jakarta"
 
     // Util
     const val LOMBOK = "org.projectlombok:lombok"


### PR DESCRIPTION
## 개요

QueryDSL Q-class 생성을 위해 사용하던 KSP(Kotlin Symbol Processing) 플러그인을 KAPT(Kotlin Annotation Processing Tool)로 교체하였습니다.
Lombok의 annotationProcessor 설정도 동일하게 kapt로 통일하였습니다.

## 변경 사항

- `build.gradle.kts`
  - `com.google.devtools.ksp` 플러그인을 `kotlin("kapt")`으로 교체하였습니다.
  - `ksp(QUERYDSL_KSP_CODEGEN)` 의존성을 `kapt(QUERYDSL_KAPT)`로 변경하였습니다.
  - Lombok `annotationProcessor` / `testAnnotationProcessor`를 `kapt` / `kaptTest`로 변경하였습니다.
  - `kapt { correctErrorTypes = true }` 설정을 추가하였습니다.
  - KAPT가 생성하는 소스 디렉토리(`build/generated/source/kapt/main`)를 `sourceSets`에 등록하였습니다.
- `buildSrc/src/main/kotlin/Libs.kt`
  - `QUERYDSL_KSP_CODEGEN` 상수를 `QUERYDSL_KAPT`로 변경하고 아티팩트를 `querydsl-apt:6.10.1:jakarta`로 업데이트하였습니다.

## 참고 사항

KAPT 전환으로 인해 Q-class 생성 경로가 `build/generated/source/ksp/main` → `build/generated/source/kapt/main`으로 변경되었습니다.
IDE에서 해당 경로를 소스 루트로 인식할 수 있도록 sourceSets에 명시적으로 추가하였습니다.

## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [ ] PR의 올바른 라벨과 리뷰어를 설정했나요?

### 관련 이슈
- Close #15