### PR TITLE
[auth] auth 서비스 단위 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,20 @@ jobs:
 
   validate-pr:
     runs-on: ubuntu-latest
+
     permissions:
       pull-requests: write
+
     steps:
       - name: Validate PR Title and Body
         env:
           TITLE: ${{ github.event.pull_request.title }}
           BODY: ${{ github.event.pull_request.body }}
+
         run: |
           echo "=== PR 제목 검증 ==="
 
-          # 제목 prefix (예: [student]) 체크
+          # 제목 prefix 체크
           if ! echo "$TITLE" | grep -qP '^\[.+\]'; then
             echo "❌ 제목에 [domain] prefix가 없습니다."
             echo "   예시: [student] QueryDSL 벌크 업데이트로 성능 개선"
@@ -33,7 +36,6 @@ jobs:
           fi
 
           echo "✅ 제목 검증 통과"
-
 
           echo "=== PR 본문 검증 ==="
 
@@ -53,50 +55,64 @@ jobs:
   setup-pr-metadata:
     runs-on: ubuntu-latest
     continue-on-error: true
+
     permissions:
       contents: read
       pull-requests: write
+      issues: write
+
     steps:
       - name: Setup PR Metadata
         env:
           GH_TOKEN: ${{ github.token }}
+
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
 
+          echo "PR Number: $PR_NUMBER"
+          echo "PR Author: $PR_AUTHOR"
+
           # 자동 리뷰어 목록
           ALL_REVIEWERS="jyx-07,hej090224,snowykte0426"
 
-          # 본인(PR AUTHOR)은 제외
-          REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
+          # PR 작성자는 제외
+          REVIEWERS=$(echo "$ALL_REVIEWERS" \
+            | tr ',' '\n' \
+            | grep -v "^${PR_AUTHOR}$" \
+            | tr '\n' ',' \
+            | sed 's/,$//')
+
+          echo "Reviewers: $REVIEWERS"
 
           # 리뷰어 등록
           if [ -n "$REVIEWERS" ]; then
-            gh pr edit $PR_NUMBER \
-              --repo ${{ github.repository }} \
+            gh pr edit "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
               --add-reviewer "$REVIEWERS"
           fi
 
-
   build-and-test:
     runs-on: ubuntu-latest
-    needs: [validate-pr]
+
+    needs:
+      - validate-pr
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Ensure Gradlew Executable
         run: chmod +x ./gradlew
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
           cache-cleanup: always

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
     testImplementation(Libs.SPRING_GRAPHQL_TEST)
     testImplementation(Libs.SPRING_SECURITY_TEST)
     testImplementation(Libs.MOCKK)
+    testImplementation(Libs.KOTEST_RUNNER)
+    testImplementation(Libs.KOTEST_ASSERTIONS)
     testCompileOnly(Libs.LOMBOK)
     kaptTest(Libs.LOMBOK)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     testImplementation(Libs.KOTLIN_TEST_JUNIT5)
     testImplementation(Libs.SPRING_GRAPHQL_TEST)
     testImplementation(Libs.SPRING_SECURITY_TEST)
+    testImplementation(Libs.MOCKK)
     testCompileOnly(Libs.LOMBOK)
     kaptTest(Libs.LOMBOK)
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -37,5 +37,6 @@ object Libs {
     const val KOTLIN_TEST_JUNIT5 = "org.jetbrains.kotlin:kotlin-test-junit5"
     const val SPRING_GRAPHQL_TEST = "org.springframework.graphql:spring-graphql-test"
     const val SPRING_SECURITY_TEST = "org.springframework.security:spring-security-test"
+    const val MOCKK = "io.mockk:mockk:1.14.6"
     const val JUNIT_PLATFORM_LAUNCHER = "org.junit.platform:junit-platform-launcher"
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -37,6 +37,8 @@ object Libs {
     const val KOTLIN_TEST_JUNIT5 = "org.jetbrains.kotlin:kotlin-test-junit5"
     const val SPRING_GRAPHQL_TEST = "org.springframework.graphql:spring-graphql-test"
     const val SPRING_SECURITY_TEST = "org.springframework.security:spring-security-test"
-    const val MOCKK = "io.mockk:mockk:1.14.6"
+    const val MOCKK = "io.mockk:mockk:1.14.9"
+    const val KOTEST_RUNNER = "io.kotest:kotest-runner-junit5:5.9.1"
+    const val KOTEST_ASSERTIONS = "io.kotest:kotest-assertions-core:5.9.1"
     const val JUNIT_PLATFORM_LAUNCHER = "org.junit.platform:junit-platform-launcher"
 }

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/FetchAuthorizationUrlServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/FetchAuthorizationUrlServiceTest.kt
@@ -1,48 +1,45 @@
 package team.incube.gsmc.domain.auth.service
 
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import team.incube.gsmc.domain.auth.port.out.OAuthPort
 import team.incube.gsmc.domain.auth.port.out.OAuthStatePersistencePort
 
-@DisplayName("FetchAuthorizationUrlService")
-class FetchAuthorizationUrlServiceTest {
-    private val oAuthPort = mockk<OAuthPort>()
-    private val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
-    private val fetchAuthorizationUrlService =
+class FetchAuthorizationUrlServiceTest : BehaviorSpec({
+    val oAuthPort = mockk<OAuthPort>()
+    val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
+    val fetchAuthorizationUrlService =
         FetchAuthorizationUrlService(
             oAuthPort = oAuthPort,
             oAuthStatePersistencePort = oAuthStatePersistencePort,
         )
 
-    @Nested
-    @DisplayName("Given 리다이렉트 URI가 주어졌을 때")
-    inner class GivenRedirectUri {
-        @Test
-        @DisplayName("When 인가 URL을 요청하면 Then state를 저장하고 인가 URL을 반환한다")
-        fun `인가 URL을 요청하면 state를 저장하고 인가 URL을 반환한다`() {
-            val redirectUri = "https://client.example.com/callback"
-            val codeVerifier = "code-verifier"
+    beforeEach { clearAllMocks() }
 
-            every { oAuthPort.createAuthorizationUrl(redirectUri, any()) } answers {
-                "https://auth.example.com/oauth?state=${secondArg<String>()}" to codeVerifier
+    Given("리다이렉트 URI가 주어졌을 때") {
+        When("인가 URL을 요청하면") {
+            Then("state를 저장하고 인가 URL을 반환한다") {
+                val redirectUri = "https://client.example.com/callback"
+                val codeVerifier = "code-verifier"
+
+                every { oAuthPort.createAuthorizationUrl(redirectUri, any()) } answers {
+                    "https://auth.example.com/oauth?state=${secondArg<String>()}" to codeVerifier
+                }
+                every { oAuthStatePersistencePort.save(any(), codeVerifier) } just runs
+
+                val result = fetchAuthorizationUrlService.execute(redirectUri)
+
+                result.state.isNotBlank() shouldBe true
+                result.url shouldBe "https://auth.example.com/oauth?state=${result.state}"
+                verify(exactly = 1) { oAuthPort.createAuthorizationUrl(redirectUri, result.state) }
+                verify(exactly = 1) { oAuthStatePersistencePort.save(result.state, codeVerifier) }
             }
-            every { oAuthStatePersistencePort.save(any(), codeVerifier) } just runs
-
-            val result = fetchAuthorizationUrlService.execute(redirectUri)
-
-            assertTrue(result.state.isNotBlank())
-            assertEquals("https://auth.example.com/oauth?state=${result.state}", result.url)
-            verify(exactly = 1) { oAuthPort.createAuthorizationUrl(redirectUri, result.state) }
-            verify(exactly = 1) { oAuthStatePersistencePort.save(result.state, codeVerifier) }
         }
     }
-}
+})

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/FetchAuthorizationUrlServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/FetchAuthorizationUrlServiceTest.kt
@@ -1,0 +1,48 @@
+package team.incube.gsmc.domain.auth.service
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import team.incube.gsmc.domain.auth.port.out.OAuthPort
+import team.incube.gsmc.domain.auth.port.out.OAuthStatePersistencePort
+
+@DisplayName("FetchAuthorizationUrlService")
+class FetchAuthorizationUrlServiceTest {
+    private val oAuthPort = mockk<OAuthPort>()
+    private val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
+    private val fetchAuthorizationUrlService =
+        FetchAuthorizationUrlService(
+            oAuthPort = oAuthPort,
+            oAuthStatePersistencePort = oAuthStatePersistencePort,
+        )
+
+    @Nested
+    @DisplayName("Given 리다이렉트 URI가 주어졌을 때")
+    inner class GivenRedirectUri {
+        @Test
+        @DisplayName("When 인가 URL을 요청하면 Then state를 저장하고 인가 URL을 반환한다")
+        fun `인가 URL을 요청하면 state를 저장하고 인가 URL을 반환한다`() {
+            val redirectUri = "https://client.example.com/callback"
+            val codeVerifier = "code-verifier"
+
+            every { oAuthPort.createAuthorizationUrl(redirectUri, any()) } answers {
+                "https://auth.example.com/oauth?state=${secondArg<String>()}" to codeVerifier
+            }
+            every { oAuthStatePersistencePort.save(any(), codeVerifier) } just runs
+
+            val result = fetchAuthorizationUrlService.execute(redirectUri)
+
+            assertTrue(result.state.isNotBlank())
+            assertEquals("https://auth.example.com/oauth?state=${result.state}", result.url)
+            verify(exactly = 1) { oAuthPort.createAuthorizationUrl(redirectUri, result.state) }
+            verify(exactly = 1) { oAuthStatePersistencePort.save(result.state, codeVerifier) }
+        }
+    }
+}

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/FetchAuthorizationUrlServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/FetchAuthorizationUrlServiceTest.kt
@@ -11,35 +11,36 @@ import io.mockk.verify
 import team.incube.gsmc.domain.auth.port.out.OAuthPort
 import team.incube.gsmc.domain.auth.port.out.OAuthStatePersistencePort
 
-class FetchAuthorizationUrlServiceTest : BehaviorSpec({
-    val oAuthPort = mockk<OAuthPort>()
-    val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
-    val fetchAuthorizationUrlService =
-        FetchAuthorizationUrlService(
-            oAuthPort = oAuthPort,
-            oAuthStatePersistencePort = oAuthStatePersistencePort,
-        )
+class FetchAuthorizationUrlServiceTest :
+    BehaviorSpec({
+        val oAuthPort = mockk<OAuthPort>()
+        val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
+        val fetchAuthorizationUrlService =
+            FetchAuthorizationUrlService(
+                oAuthPort = oAuthPort,
+                oAuthStatePersistencePort = oAuthStatePersistencePort,
+            )
 
-    beforeEach { clearAllMocks() }
+        beforeEach { clearAllMocks() }
 
-    Given("리다이렉트 URI가 주어졌을 때") {
-        When("인가 URL을 요청하면") {
-            Then("state를 저장하고 인가 URL을 반환한다") {
-                val redirectUri = "https://client.example.com/callback"
-                val codeVerifier = "code-verifier"
+        Given("리다이렉트 URI가 주어졌을 때") {
+            When("인가 URL을 요청하면") {
+                Then("state를 저장하고 인가 URL을 반환한다") {
+                    val redirectUri = "https://client.example.com/callback"
+                    val codeVerifier = "code-verifier"
 
-                every { oAuthPort.createAuthorizationUrl(redirectUri, any()) } answers {
-                    "https://auth.example.com/oauth?state=${secondArg<String>()}" to codeVerifier
+                    every { oAuthPort.createAuthorizationUrl(redirectUri, any()) } answers {
+                        "https://auth.example.com/oauth?state=${secondArg<String>()}" to codeVerifier
+                    }
+                    every { oAuthStatePersistencePort.save(any(), codeVerifier) } just runs
+
+                    val result = fetchAuthorizationUrlService.execute(redirectUri)
+
+                    result.state.isNotBlank() shouldBe true
+                    result.url shouldBe "https://auth.example.com/oauth?state=${result.state}"
+                    verify(exactly = 1) { oAuthPort.createAuthorizationUrl(redirectUri, result.state) }
+                    verify(exactly = 1) { oAuthStatePersistencePort.save(result.state, codeVerifier) }
                 }
-                every { oAuthStatePersistencePort.save(any(), codeVerifier) } just runs
-
-                val result = fetchAuthorizationUrlService.execute(redirectUri)
-
-                result.state.isNotBlank() shouldBe true
-                result.url shouldBe "https://auth.example.com/oauth?state=${result.state}"
-                verify(exactly = 1) { oAuthPort.createAuthorizationUrl(redirectUri, result.state) }
-                verify(exactly = 1) { oAuthStatePersistencePort.save(result.state, codeVerifier) }
             }
         }
-    }
-})
+    })

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
@@ -62,18 +62,20 @@ class LoginServiceTest {
             every { authTokenPort.refreshTokenExpiresIn } returns 7200
             every { refreshTokenPersistencePort.save(user.userId, "refresh-token") } just runs
 
+            val before = System.currentTimeMillis()
             val result =
                 loginService.execute(
                     code = "code",
                     state = "state",
                     redirectUri = "https://client.example.com/callback",
                 )
+            val after = System.currentTimeMillis()
 
             assertEquals("access-token", result.accessToken)
             assertEquals("refresh-token", result.refreshToken)
             assertEquals(UserRole.STUDENT, result.role)
-            assertTrue(result.accessTokenExpiresIn > System.currentTimeMillis())
-            assertTrue(result.refreshTokenExpiresIn > result.accessTokenExpiresIn)
+            assertTrue(result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000))
+            assertTrue(result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000))
             verify(exactly = 0) { userPersistencePort.save(any()) }
             verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "refresh-token") }
         }
@@ -156,6 +158,9 @@ class LoginServiceTest {
             assertEquals(UserRole.TEACHER, result.role)
             assertEquals(teacherEmail, userSlot.captured.userName)
             assertEquals(UserRole.TEACHER, userSlot.captured.userRole)
+            assertEquals(null, userSlot.captured.userGrade)
+            assertEquals(null, userSlot.captured.userClassNumber)
+            assertEquals(null, userSlot.captured.userNumber)
         }
     }
 

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
@@ -1,17 +1,15 @@
 package team.incube.gsmc.domain.auth.service
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.support.SimpleTransactionStatus
@@ -27,15 +25,14 @@ import team.incube.gsmc.domain.user.UserRole
 import team.incube.gsmc.global.exception.ErrorCode
 import team.incube.gsmc.global.exception.GsmcException
 
-@DisplayName("LoginService")
-class LoginServiceTest {
-    private val oAuthPort = mockk<OAuthPort>()
-    private val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
-    private val userPersistencePort = mockk<UserPersistencePort>()
-    private val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
-    private val authTokenPort = mockk<AuthTokenPort>()
-    private val transactionManager = mockk<PlatformTransactionManager>()
-    private val loginService =
+class LoginServiceTest : BehaviorSpec({
+    val oAuthPort = mockk<OAuthPort>()
+    val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
+    val userPersistencePort = mockk<UserPersistencePort>()
+    val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+    val authTokenPort = mockk<AuthTokenPort>()
+    val transactionManager = mockk<PlatformTransactionManager>()
+    val loginService =
         LoginService(
             oAuthPort = oAuthPort,
             oAuthStatePersistencePort = oAuthStatePersistencePort,
@@ -45,154 +42,15 @@ class LoginServiceTest {
             transactionManager = transactionManager,
         )
 
-    @Nested
-    @DisplayName("Given 유효한 OAuth state가 주어졌을 때")
-    inner class GivenValidOAuthState {
-        @Test
-        @DisplayName("When 기존 사용자가 로그인하면 Then 토큰을 발급하고 리프레시 토큰을 저장한다")
-        fun `기존 사용자가 로그인하면 토큰을 발급하고 리프레시 토큰을 저장한다`() {
-            val user = studentUser()
+    beforeEach { clearAllMocks() }
 
-            everySuccessfulTransaction()
-            everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
-            every { userPersistencePort.findByEmail(user.userEmail) } returns user
-            every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "access-token"
-            every { authTokenPort.generateRefreshToken(user.userId) } returns "refresh-token"
-            every { authTokenPort.accessTokenExpiresIn } returns 3600
-            every { authTokenPort.refreshTokenExpiresIn } returns 7200
-            every { refreshTokenPersistencePort.save(user.userId, "refresh-token") } just runs
-
-            val before = System.currentTimeMillis()
-            val result =
-                loginService.execute(
-                    code = "code",
-                    state = "state",
-                    redirectUri = "https://client.example.com/callback",
-                )
-            val after = System.currentTimeMillis()
-
-            assertEquals("access-token", result.accessToken)
-            assertEquals("refresh-token", result.refreshToken)
-            assertEquals(UserRole.STUDENT, result.role)
-            assertTrue(result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000))
-            assertTrue(result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000))
-            verify(exactly = 0) { userPersistencePort.save(any()) }
-            verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "refresh-token") }
-        }
-
-        @Test
-        @DisplayName("When 신규 학생이 로그인하면 Then 학생 사용자로 저장한 뒤 토큰을 발급한다")
-        fun `신규 학생이 로그인하면 학생 사용자로 저장한 뒤 토큰을 발급한다`() {
-            val savedUser = studentUser()
-            val userSlot = slot<User>()
-
-            everySuccessfulTransaction()
-            everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
-            every { userPersistencePort.findByEmail("student@gsm.hs.kr") } returns null
-            every { userPersistencePort.save(capture(userSlot)) } returns savedUser
-            every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
-            every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
-            every { authTokenPort.accessTokenExpiresIn } returns 3600
-            every { authTokenPort.refreshTokenExpiresIn } returns 7200
-            every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
-
-            val result =
-                loginService.execute(
-                    code = "code",
-                    state = "state",
-                    redirectUri = "https://client.example.com/callback",
-                )
-
-            assertEquals(UserRole.STUDENT, result.role)
-            assertEquals("학생", userSlot.captured.userName)
-            assertEquals("student@gsm.hs.kr", userSlot.captured.userEmail)
-            assertEquals(2, userSlot.captured.userGrade)
-            assertEquals(3, userSlot.captured.userClassNumber)
-            assertEquals(4, userSlot.captured.userNumber)
-            assertEquals(UserRole.STUDENT, userSlot.captured.userRole)
-        }
-
-        @Test
-        @DisplayName("When 신규 교사가 로그인하면 Then 이메일을 이름으로 사용해 교사 사용자로 저장한다")
-        fun `신규 교사가 로그인하면 이메일을 이름으로 사용해 교사 사용자로 저장한다`() {
-            val teacherEmail = "teacher@gsm.hs.kr"
-            val savedUser =
-                User(
-                    userId = 2,
-                    userName = teacherEmail,
-                    userEmail = teacherEmail,
-                    userGrade = null,
-                    userClassNumber = null,
-                    userNumber = null,
-                    userRole = UserRole.TEACHER,
-                )
-            val userSlot = slot<User>()
-
-            everySuccessfulTransaction()
-            everyOAuthLogin(
-                oAuthUserInfo =
-                    OAuthUserInfo(
-                        email = teacherEmail,
-                        isStudent = false,
-                        name = null,
-                        grade = null,
-                        classNum = null,
-                        number = null,
-                    ),
-            )
-            every { userPersistencePort.findByEmail(teacherEmail) } returns null
-            every { userPersistencePort.save(capture(userSlot)) } returns savedUser
-            every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
-            every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
-            every { authTokenPort.accessTokenExpiresIn } returns 3600
-            every { authTokenPort.refreshTokenExpiresIn } returns 7200
-            every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
-
-            val result =
-                loginService.execute(
-                    code = "code",
-                    state = "state",
-                    redirectUri = "https://client.example.com/callback",
-                )
-
-            assertEquals(UserRole.TEACHER, result.role)
-            assertEquals(teacherEmail, userSlot.captured.userName)
-            assertEquals(UserRole.TEACHER, userSlot.captured.userRole)
-            assertEquals(null, userSlot.captured.userGrade)
-            assertEquals(null, userSlot.captured.userClassNumber)
-            assertEquals(null, userSlot.captured.userNumber)
-        }
-    }
-
-    @Nested
-    @DisplayName("Given OAuth state가 유효하지 않을 때")
-    inner class GivenInvalidOAuthState {
-        @Test
-        @DisplayName("When 로그인을 요청하면 Then INVALID_OAUTH_STATE 예외가 발생한다")
-        fun `로그인을 요청하면 INVALID_OAUTH_STATE 예외가 발생한다`() {
-            every { oAuthStatePersistencePort.findAndDelete("invalid-state") } returns null
-
-            val exception =
-                assertThrows(GsmcException::class.java) {
-                    loginService.execute(
-                        code = "code",
-                        state = "invalid-state",
-                        redirectUri = "https://client.example.com/callback",
-                    )
-                }
-
-            assertEquals(ErrorCode.INVALID_OAUTH_STATE, exception.errorCode)
-            verify(exactly = 0) { oAuthPort.exchangeCodeForToken(any(), any(), any()) }
-        }
-    }
-
-    private fun everySuccessfulTransaction() {
+    fun everySuccessfulTransaction() {
         every { transactionManager.getTransaction(any<TransactionDefinition>()) } returns SimpleTransactionStatus()
         every { transactionManager.commit(any()) } just runs
         every { transactionManager.rollback(any()) } just runs
     }
 
-    private fun everyOAuthLogin(oAuthUserInfo: OAuthUserInfo) {
+    fun everyOAuthLogin(oAuthUserInfo: OAuthUserInfo) {
         every { oAuthStatePersistencePort.findAndDelete("state") } returns "code-verifier"
         every {
             oAuthPort.exchangeCodeForToken(
@@ -204,7 +62,7 @@ class LoginServiceTest {
         every { oAuthPort.getUserInfo("oauth-access-token") } returns oAuthUserInfo
     }
 
-    private fun studentOAuthUserInfo(): OAuthUserInfo =
+    fun studentOAuthUserInfo() =
         OAuthUserInfo(
             email = "student@gsm.hs.kr",
             isStudent = true,
@@ -214,7 +72,7 @@ class LoginServiceTest {
             number = 4,
         )
 
-    private fun studentUser(): User =
+    fun studentUser() =
         User(
             userId = 1,
             userName = "학생",
@@ -224,4 +82,141 @@ class LoginServiceTest {
             userNumber = 4,
             userRole = UserRole.STUDENT,
         )
-}
+
+    Given("유효한 OAuth state가 주어졌을 때") {
+        When("기존 사용자가 로그인하면") {
+            Then("토큰을 발급하고 리프레시 토큰을 저장한다") {
+                val user = studentUser()
+
+                everySuccessfulTransaction()
+                everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
+                every { userPersistencePort.findByEmail(user.userEmail) } returns user
+                every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "access-token"
+                every { authTokenPort.generateRefreshToken(user.userId) } returns "refresh-token"
+                every { authTokenPort.accessTokenExpiresIn } returns 3600
+                every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                every { refreshTokenPersistencePort.save(user.userId, "refresh-token") } just runs
+
+                val before = System.currentTimeMillis()
+                val result =
+                    loginService.execute(
+                        code = "code",
+                        state = "state",
+                        redirectUri = "https://client.example.com/callback",
+                    )
+                val after = System.currentTimeMillis()
+
+                result.accessToken shouldBe "access-token"
+                result.refreshToken shouldBe "refresh-token"
+                result.role shouldBe UserRole.STUDENT
+                (result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000)) shouldBe true
+                (result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000)) shouldBe true
+                verify(exactly = 0) { userPersistencePort.save(any()) }
+                verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "refresh-token") }
+            }
+        }
+
+        When("신규 학생이 로그인하면") {
+            Then("학생 사용자로 저장한 뒤 토큰을 발급한다") {
+                val savedUser = studentUser()
+                val userSlot = slot<User>()
+
+                everySuccessfulTransaction()
+                everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
+                every { userPersistencePort.findByEmail("student@gsm.hs.kr") } returns null
+                every { userPersistencePort.save(capture(userSlot)) } returns savedUser
+                every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
+                every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
+                every { authTokenPort.accessTokenExpiresIn } returns 3600
+                every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
+
+                val result =
+                    loginService.execute(
+                        code = "code",
+                        state = "state",
+                        redirectUri = "https://client.example.com/callback",
+                    )
+
+                result.role shouldBe UserRole.STUDENT
+                userSlot.captured.userName shouldBe "학생"
+                userSlot.captured.userEmail shouldBe "student@gsm.hs.kr"
+                userSlot.captured.userGrade shouldBe 2
+                userSlot.captured.userClassNumber shouldBe 3
+                userSlot.captured.userNumber shouldBe 4
+                userSlot.captured.userRole shouldBe UserRole.STUDENT
+            }
+        }
+
+        When("신규 교사가 로그인하면") {
+            Then("이메일을 이름으로 사용해 교사 사용자로 저장한다") {
+                val teacherEmail = "teacher@gsm.hs.kr"
+                val savedUser =
+                    User(
+                        userId = 2,
+                        userName = teacherEmail,
+                        userEmail = teacherEmail,
+                        userGrade = null,
+                        userClassNumber = null,
+                        userNumber = null,
+                        userRole = UserRole.TEACHER,
+                    )
+                val userSlot = slot<User>()
+
+                everySuccessfulTransaction()
+                everyOAuthLogin(
+                    oAuthUserInfo =
+                        OAuthUserInfo(
+                            email = teacherEmail,
+                            isStudent = false,
+                            name = null,
+                            grade = null,
+                            classNum = null,
+                            number = null,
+                        ),
+                )
+                every { userPersistencePort.findByEmail(teacherEmail) } returns null
+                every { userPersistencePort.save(capture(userSlot)) } returns savedUser
+                every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
+                every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
+                every { authTokenPort.accessTokenExpiresIn } returns 3600
+                every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
+
+                val result =
+                    loginService.execute(
+                        code = "code",
+                        state = "state",
+                        redirectUri = "https://client.example.com/callback",
+                    )
+
+                result.role shouldBe UserRole.TEACHER
+                userSlot.captured.userName shouldBe teacherEmail
+                userSlot.captured.userRole shouldBe UserRole.TEACHER
+                userSlot.captured.userGrade shouldBe null
+                userSlot.captured.userClassNumber shouldBe null
+                userSlot.captured.userNumber shouldBe null
+            }
+        }
+    }
+
+    Given("OAuth state가 유효하지 않을 때") {
+        When("로그인을 요청하면") {
+            Then("INVALID_OAUTH_STATE 예외가 발생한다") {
+                every { oAuthStatePersistencePort.findAndDelete("invalid-state") } returns null
+
+                val exception =
+                    shouldThrow<GsmcException> {
+                        loginService.execute(
+                            code = "code",
+                            state = "invalid-state",
+                            redirectUri = "https://client.example.com/callback",
+                        )
+                    }
+
+                exception.errorCode shouldBe ErrorCode.INVALID_OAUTH_STATE
+                verify(exactly = 0) { oAuthPort.exchangeCodeForToken(any(), any(), any()) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
@@ -25,198 +25,201 @@ import team.incube.gsmc.domain.user.UserRole
 import team.incube.gsmc.global.exception.ErrorCode
 import team.incube.gsmc.global.exception.GsmcException
 
-class LoginServiceTest : BehaviorSpec({
-    val oAuthPort = mockk<OAuthPort>()
-    val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
-    val userPersistencePort = mockk<UserPersistencePort>()
-    val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
-    val authTokenPort = mockk<AuthTokenPort>()
-    val transactionManager = mockk<PlatformTransactionManager>()
-    val loginService =
-        LoginService(
-            oAuthPort = oAuthPort,
-            oAuthStatePersistencePort = oAuthStatePersistencePort,
-            userPersistencePort = userPersistencePort,
-            refreshTokenPersistencePort = refreshTokenPersistencePort,
-            authTokenPort = authTokenPort,
-            transactionManager = transactionManager,
-        )
-
-    beforeEach { clearAllMocks() }
-
-    fun everySuccessfulTransaction() {
-        every { transactionManager.getTransaction(any<TransactionDefinition>()) } returns SimpleTransactionStatus()
-        every { transactionManager.commit(any()) } just runs
-        every { transactionManager.rollback(any()) } just runs
-    }
-
-    fun everyOAuthLogin(oAuthUserInfo: OAuthUserInfo) {
-        every { oAuthStatePersistencePort.findAndDelete("state") } returns "code-verifier"
-        every {
-            oAuthPort.exchangeCodeForToken(
-                code = "code",
-                redirectUri = "https://client.example.com/callback",
-                codeVerifier = "code-verifier",
+class LoginServiceTest :
+    BehaviorSpec({
+        val oAuthPort = mockk<OAuthPort>()
+        val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
+        val userPersistencePort = mockk<UserPersistencePort>()
+        val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+        val authTokenPort = mockk<AuthTokenPort>()
+        val transactionManager = mockk<PlatformTransactionManager>()
+        val loginService =
+            LoginService(
+                oAuthPort = oAuthPort,
+                oAuthStatePersistencePort = oAuthStatePersistencePort,
+                userPersistencePort = userPersistencePort,
+                refreshTokenPersistencePort = refreshTokenPersistencePort,
+                authTokenPort = authTokenPort,
+                transactionManager = transactionManager,
             )
-        } returns OAuthTokenResult(accessToken = "oauth-access-token", refreshToken = null, expiresIn = 3600)
-        every { oAuthPort.getUserInfo("oauth-access-token") } returns oAuthUserInfo
-    }
 
-    fun studentOAuthUserInfo() =
-        OAuthUserInfo(
-            email = "student@gsm.hs.kr",
-            isStudent = true,
-            name = "학생",
-            grade = 2,
-            classNum = 3,
-            number = 4,
-        )
+        beforeEach { clearAllMocks() }
 
-    fun studentUser() =
-        User(
-            userId = 1,
-            userName = "학생",
-            userEmail = "student@gsm.hs.kr",
-            userGrade = 2,
-            userClassNumber = 3,
-            userNumber = 4,
-            userRole = UserRole.STUDENT,
-        )
-
-    Given("유효한 OAuth state가 주어졌을 때") {
-        When("기존 사용자가 로그인하면") {
-            Then("토큰을 발급하고 리프레시 토큰을 저장한다") {
-                val user = studentUser()
-
-                everySuccessfulTransaction()
-                everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
-                every { userPersistencePort.findByEmail(user.userEmail) } returns user
-                every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "access-token"
-                every { authTokenPort.generateRefreshToken(user.userId) } returns "refresh-token"
-                every { authTokenPort.accessTokenExpiresIn } returns 3600
-                every { authTokenPort.refreshTokenExpiresIn } returns 7200
-                every { refreshTokenPersistencePort.save(user.userId, "refresh-token") } just runs
-
-                val before = System.currentTimeMillis()
-                val result =
-                    loginService.execute(
-                        code = "code",
-                        state = "state",
-                        redirectUri = "https://client.example.com/callback",
-                    )
-                val after = System.currentTimeMillis()
-
-                result.accessToken shouldBe "access-token"
-                result.refreshToken shouldBe "refresh-token"
-                result.role shouldBe UserRole.STUDENT
-                (result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000)) shouldBe true
-                (result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000)) shouldBe true
-                verify(exactly = 0) { userPersistencePort.save(any()) }
-                verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "refresh-token") }
-            }
+        fun everySuccessfulTransaction() {
+            every { transactionManager.getTransaction(any<TransactionDefinition>()) } returns SimpleTransactionStatus()
+            every { transactionManager.commit(any()) } just runs
+            every { transactionManager.rollback(any()) } just runs
         }
 
-        When("신규 학생이 로그인하면") {
-            Then("학생 사용자로 저장한 뒤 토큰을 발급한다") {
-                val savedUser = studentUser()
-                val userSlot = slot<User>()
-
-                everySuccessfulTransaction()
-                everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
-                every { userPersistencePort.findByEmail("student@gsm.hs.kr") } returns null
-                every { userPersistencePort.save(capture(userSlot)) } returns savedUser
-                every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
-                every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
-                every { authTokenPort.accessTokenExpiresIn } returns 3600
-                every { authTokenPort.refreshTokenExpiresIn } returns 7200
-                every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
-
-                val result =
-                    loginService.execute(
-                        code = "code",
-                        state = "state",
-                        redirectUri = "https://client.example.com/callback",
-                    )
-
-                result.role shouldBe UserRole.STUDENT
-                userSlot.captured.userName shouldBe "학생"
-                userSlot.captured.userEmail shouldBe "student@gsm.hs.kr"
-                userSlot.captured.userGrade shouldBe 2
-                userSlot.captured.userClassNumber shouldBe 3
-                userSlot.captured.userNumber shouldBe 4
-                userSlot.captured.userRole shouldBe UserRole.STUDENT
-            }
-        }
-
-        When("신규 교사가 로그인하면") {
-            Then("이메일을 이름으로 사용해 교사 사용자로 저장한다") {
-                val teacherEmail = "teacher@gsm.hs.kr"
-                val savedUser =
-                    User(
-                        userId = 2,
-                        userName = teacherEmail,
-                        userEmail = teacherEmail,
-                        userGrade = null,
-                        userClassNumber = null,
-                        userNumber = null,
-                        userRole = UserRole.TEACHER,
-                    )
-                val userSlot = slot<User>()
-
-                everySuccessfulTransaction()
-                everyOAuthLogin(
-                    oAuthUserInfo =
-                        OAuthUserInfo(
-                            email = teacherEmail,
-                            isStudent = false,
-                            name = null,
-                            grade = null,
-                            classNum = null,
-                            number = null,
-                        ),
+        fun everyOAuthLogin(oAuthUserInfo: OAuthUserInfo) {
+            every { oAuthStatePersistencePort.findAndDelete("state") } returns "code-verifier"
+            every {
+                oAuthPort.exchangeCodeForToken(
+                    code = "code",
+                    redirectUri = "https://client.example.com/callback",
+                    codeVerifier = "code-verifier",
                 )
-                every { userPersistencePort.findByEmail(teacherEmail) } returns null
-                every { userPersistencePort.save(capture(userSlot)) } returns savedUser
-                every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
-                every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
-                every { authTokenPort.accessTokenExpiresIn } returns 3600
-                every { authTokenPort.refreshTokenExpiresIn } returns 7200
-                every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
-
-                val result =
-                    loginService.execute(
-                        code = "code",
-                        state = "state",
-                        redirectUri = "https://client.example.com/callback",
-                    )
-
-                result.role shouldBe UserRole.TEACHER
-                userSlot.captured.userName shouldBe teacherEmail
-                userSlot.captured.userRole shouldBe UserRole.TEACHER
-                userSlot.captured.userGrade shouldBe null
-                userSlot.captured.userClassNumber shouldBe null
-                userSlot.captured.userNumber shouldBe null
-            }
+            } returns OAuthTokenResult(accessToken = "oauth-access-token", refreshToken = null, expiresIn = 3600)
+            every { oAuthPort.getUserInfo("oauth-access-token") } returns oAuthUserInfo
         }
-    }
 
-    Given("OAuth state가 유효하지 않을 때") {
-        When("로그인을 요청하면") {
-            Then("INVALID_OAUTH_STATE 예외가 발생한다") {
-                every { oAuthStatePersistencePort.findAndDelete("invalid-state") } returns null
+        fun studentOAuthUserInfo() =
+            OAuthUserInfo(
+                email = "student@gsm.hs.kr",
+                isStudent = true,
+                name = "학생",
+                grade = 2,
+                classNum = 3,
+                number = 4,
+            )
 
-                val exception =
-                    shouldThrow<GsmcException> {
+        fun studentUser() =
+            User(
+                userId = 1,
+                userName = "학생",
+                userEmail = "student@gsm.hs.kr",
+                userGrade = 2,
+                userClassNumber = 3,
+                userNumber = 4,
+                userRole = UserRole.STUDENT,
+            )
+
+        Given("유효한 OAuth state가 주어졌을 때") {
+            When("기존 사용자가 로그인하면") {
+                Then("토큰을 발급하고 리프레시 토큰을 저장한다") {
+                    val user = studentUser()
+
+                    everySuccessfulTransaction()
+                    everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
+                    every { userPersistencePort.findByEmail(user.userEmail) } returns user
+                    every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "access-token"
+                    every { authTokenPort.generateRefreshToken(user.userId) } returns "refresh-token"
+                    every { authTokenPort.accessTokenExpiresIn } returns 3600
+                    every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                    every { refreshTokenPersistencePort.save(user.userId, "refresh-token") } just runs
+
+                    val before = System.currentTimeMillis()
+                    val result =
                         loginService.execute(
                             code = "code",
-                            state = "invalid-state",
+                            state = "state",
                             redirectUri = "https://client.example.com/callback",
                         )
-                    }
+                    val after = System.currentTimeMillis()
 
-                exception.errorCode shouldBe ErrorCode.INVALID_OAUTH_STATE
-                verify(exactly = 0) { oAuthPort.exchangeCodeForToken(any(), any(), any()) }
+                    result.accessToken shouldBe "access-token"
+                    result.refreshToken shouldBe "refresh-token"
+                    result.role shouldBe UserRole.STUDENT
+                    (result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000)) shouldBe true
+                    (result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000)) shouldBe true
+                    verify(exactly = 0) { userPersistencePort.save(any()) }
+                    verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "refresh-token") }
+                }
+            }
+
+            When("신규 학생이 로그인하면") {
+                Then("학생 사용자로 저장한 뒤 토큰을 발급한다") {
+                    val savedUser = studentUser()
+                    val userSlot = slot<User>()
+
+                    everySuccessfulTransaction()
+                    everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
+                    every { userPersistencePort.findByEmail("student@gsm.hs.kr") } returns null
+                    every { userPersistencePort.save(capture(userSlot)) } returns savedUser
+                    every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns
+                        "access-token"
+                    every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
+                    every { authTokenPort.accessTokenExpiresIn } returns 3600
+                    every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                    every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
+
+                    val result =
+                        loginService.execute(
+                            code = "code",
+                            state = "state",
+                            redirectUri = "https://client.example.com/callback",
+                        )
+
+                    result.role shouldBe UserRole.STUDENT
+                    userSlot.captured.userName shouldBe "학생"
+                    userSlot.captured.userEmail shouldBe "student@gsm.hs.kr"
+                    userSlot.captured.userGrade shouldBe 2
+                    userSlot.captured.userClassNumber shouldBe 3
+                    userSlot.captured.userNumber shouldBe 4
+                    userSlot.captured.userRole shouldBe UserRole.STUDENT
+                }
+            }
+
+            When("신규 교사가 로그인하면") {
+                Then("이메일을 이름으로 사용해 교사 사용자로 저장한다") {
+                    val teacherEmail = "teacher@gsm.hs.kr"
+                    val savedUser =
+                        User(
+                            userId = 2,
+                            userName = teacherEmail,
+                            userEmail = teacherEmail,
+                            userGrade = null,
+                            userClassNumber = null,
+                            userNumber = null,
+                            userRole = UserRole.TEACHER,
+                        )
+                    val userSlot = slot<User>()
+
+                    everySuccessfulTransaction()
+                    everyOAuthLogin(
+                        oAuthUserInfo =
+                            OAuthUserInfo(
+                                email = teacherEmail,
+                                isStudent = false,
+                                name = null,
+                                grade = null,
+                                classNum = null,
+                                number = null,
+                            ),
+                    )
+                    every { userPersistencePort.findByEmail(teacherEmail) } returns null
+                    every { userPersistencePort.save(capture(userSlot)) } returns savedUser
+                    every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns
+                        "access-token"
+                    every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
+                    every { authTokenPort.accessTokenExpiresIn } returns 3600
+                    every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                    every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
+
+                    val result =
+                        loginService.execute(
+                            code = "code",
+                            state = "state",
+                            redirectUri = "https://client.example.com/callback",
+                        )
+
+                    result.role shouldBe UserRole.TEACHER
+                    userSlot.captured.userName shouldBe teacherEmail
+                    userSlot.captured.userRole shouldBe UserRole.TEACHER
+                    userSlot.captured.userGrade shouldBe null
+                    userSlot.captured.userClassNumber shouldBe null
+                    userSlot.captured.userNumber shouldBe null
+                }
             }
         }
-    }
-})
+
+        Given("OAuth state가 유효하지 않을 때") {
+            When("로그인을 요청하면") {
+                Then("INVALID_OAUTH_STATE 예외가 발생한다") {
+                    every { oAuthStatePersistencePort.findAndDelete("invalid-state") } returns null
+
+                    val exception =
+                        shouldThrow<GsmcException> {
+                            loginService.execute(
+                                code = "code",
+                                state = "invalid-state",
+                                redirectUri = "https://client.example.com/callback",
+                            )
+                        }
+
+                    exception.errorCode shouldBe ErrorCode.INVALID_OAUTH_STATE
+                    verify(exactly = 0) { oAuthPort.exchangeCodeForToken(any(), any(), any()) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/LoginServiceTest.kt
@@ -1,0 +1,222 @@
+package team.incube.gsmc.domain.auth.service
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.SimpleTransactionStatus
+import team.incube.gsmc.domain.auth.OAuthTokenResult
+import team.incube.gsmc.domain.auth.OAuthUserInfo
+import team.incube.gsmc.domain.auth.port.out.AuthTokenPort
+import team.incube.gsmc.domain.auth.port.out.OAuthPort
+import team.incube.gsmc.domain.auth.port.out.OAuthStatePersistencePort
+import team.incube.gsmc.domain.auth.port.out.RefreshTokenPersistencePort
+import team.incube.gsmc.domain.auth.port.out.UserPersistencePort
+import team.incube.gsmc.domain.user.User
+import team.incube.gsmc.domain.user.UserRole
+import team.incube.gsmc.global.exception.ErrorCode
+import team.incube.gsmc.global.exception.GsmcException
+
+@DisplayName("LoginService")
+class LoginServiceTest {
+    private val oAuthPort = mockk<OAuthPort>()
+    private val oAuthStatePersistencePort = mockk<OAuthStatePersistencePort>()
+    private val userPersistencePort = mockk<UserPersistencePort>()
+    private val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+    private val authTokenPort = mockk<AuthTokenPort>()
+    private val transactionManager = mockk<PlatformTransactionManager>()
+    private val loginService =
+        LoginService(
+            oAuthPort = oAuthPort,
+            oAuthStatePersistencePort = oAuthStatePersistencePort,
+            userPersistencePort = userPersistencePort,
+            refreshTokenPersistencePort = refreshTokenPersistencePort,
+            authTokenPort = authTokenPort,
+            transactionManager = transactionManager,
+        )
+
+    @Nested
+    @DisplayName("Given 유효한 OAuth state가 주어졌을 때")
+    inner class GivenValidOAuthState {
+        @Test
+        @DisplayName("When 기존 사용자가 로그인하면 Then 토큰을 발급하고 리프레시 토큰을 저장한다")
+        fun `기존 사용자가 로그인하면 토큰을 발급하고 리프레시 토큰을 저장한다`() {
+            val user = studentUser()
+
+            everySuccessfulTransaction()
+            everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
+            every { userPersistencePort.findByEmail(user.userEmail) } returns user
+            every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "access-token"
+            every { authTokenPort.generateRefreshToken(user.userId) } returns "refresh-token"
+            every { authTokenPort.accessTokenExpiresIn } returns 3600
+            every { authTokenPort.refreshTokenExpiresIn } returns 7200
+            every { refreshTokenPersistencePort.save(user.userId, "refresh-token") } just runs
+
+            val result =
+                loginService.execute(
+                    code = "code",
+                    state = "state",
+                    redirectUri = "https://client.example.com/callback",
+                )
+
+            assertEquals("access-token", result.accessToken)
+            assertEquals("refresh-token", result.refreshToken)
+            assertEquals(UserRole.STUDENT, result.role)
+            assertTrue(result.accessTokenExpiresIn > System.currentTimeMillis())
+            assertTrue(result.refreshTokenExpiresIn > result.accessTokenExpiresIn)
+            verify(exactly = 0) { userPersistencePort.save(any()) }
+            verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "refresh-token") }
+        }
+
+        @Test
+        @DisplayName("When 신규 학생이 로그인하면 Then 학생 사용자로 저장한 뒤 토큰을 발급한다")
+        fun `신규 학생이 로그인하면 학생 사용자로 저장한 뒤 토큰을 발급한다`() {
+            val savedUser = studentUser()
+            val userSlot = slot<User>()
+
+            everySuccessfulTransaction()
+            everyOAuthLogin(oAuthUserInfo = studentOAuthUserInfo())
+            every { userPersistencePort.findByEmail("student@gsm.hs.kr") } returns null
+            every { userPersistencePort.save(capture(userSlot)) } returns savedUser
+            every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
+            every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
+            every { authTokenPort.accessTokenExpiresIn } returns 3600
+            every { authTokenPort.refreshTokenExpiresIn } returns 7200
+            every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
+
+            val result =
+                loginService.execute(
+                    code = "code",
+                    state = "state",
+                    redirectUri = "https://client.example.com/callback",
+                )
+
+            assertEquals(UserRole.STUDENT, result.role)
+            assertEquals("학생", userSlot.captured.userName)
+            assertEquals("student@gsm.hs.kr", userSlot.captured.userEmail)
+            assertEquals(2, userSlot.captured.userGrade)
+            assertEquals(3, userSlot.captured.userClassNumber)
+            assertEquals(4, userSlot.captured.userNumber)
+            assertEquals(UserRole.STUDENT, userSlot.captured.userRole)
+        }
+
+        @Test
+        @DisplayName("When 신규 교사가 로그인하면 Then 이메일을 이름으로 사용해 교사 사용자로 저장한다")
+        fun `신규 교사가 로그인하면 이메일을 이름으로 사용해 교사 사용자로 저장한다`() {
+            val teacherEmail = "teacher@gsm.hs.kr"
+            val savedUser =
+                User(
+                    userId = 2,
+                    userName = teacherEmail,
+                    userEmail = teacherEmail,
+                    userGrade = null,
+                    userClassNumber = null,
+                    userNumber = null,
+                    userRole = UserRole.TEACHER,
+                )
+            val userSlot = slot<User>()
+
+            everySuccessfulTransaction()
+            everyOAuthLogin(
+                oAuthUserInfo =
+                    OAuthUserInfo(
+                        email = teacherEmail,
+                        isStudent = false,
+                        name = null,
+                        grade = null,
+                        classNum = null,
+                        number = null,
+                    ),
+            )
+            every { userPersistencePort.findByEmail(teacherEmail) } returns null
+            every { userPersistencePort.save(capture(userSlot)) } returns savedUser
+            every { authTokenPort.generateAccessToken(savedUser.userId, savedUser.userRole) } returns "access-token"
+            every { authTokenPort.generateRefreshToken(savedUser.userId) } returns "refresh-token"
+            every { authTokenPort.accessTokenExpiresIn } returns 3600
+            every { authTokenPort.refreshTokenExpiresIn } returns 7200
+            every { refreshTokenPersistencePort.save(savedUser.userId, "refresh-token") } just runs
+
+            val result =
+                loginService.execute(
+                    code = "code",
+                    state = "state",
+                    redirectUri = "https://client.example.com/callback",
+                )
+
+            assertEquals(UserRole.TEACHER, result.role)
+            assertEquals(teacherEmail, userSlot.captured.userName)
+            assertEquals(UserRole.TEACHER, userSlot.captured.userRole)
+        }
+    }
+
+    @Nested
+    @DisplayName("Given OAuth state가 유효하지 않을 때")
+    inner class GivenInvalidOAuthState {
+        @Test
+        @DisplayName("When 로그인을 요청하면 Then INVALID_OAUTH_STATE 예외가 발생한다")
+        fun `로그인을 요청하면 INVALID_OAUTH_STATE 예외가 발생한다`() {
+            every { oAuthStatePersistencePort.findAndDelete("invalid-state") } returns null
+
+            val exception =
+                assertThrows(GsmcException::class.java) {
+                    loginService.execute(
+                        code = "code",
+                        state = "invalid-state",
+                        redirectUri = "https://client.example.com/callback",
+                    )
+                }
+
+            assertEquals(ErrorCode.INVALID_OAUTH_STATE, exception.errorCode)
+            verify(exactly = 0) { oAuthPort.exchangeCodeForToken(any(), any(), any()) }
+        }
+    }
+
+    private fun everySuccessfulTransaction() {
+        every { transactionManager.getTransaction(any<TransactionDefinition>()) } returns SimpleTransactionStatus()
+        every { transactionManager.commit(any()) } just runs
+        every { transactionManager.rollback(any()) } just runs
+    }
+
+    private fun everyOAuthLogin(oAuthUserInfo: OAuthUserInfo) {
+        every { oAuthStatePersistencePort.findAndDelete("state") } returns "code-verifier"
+        every {
+            oAuthPort.exchangeCodeForToken(
+                code = "code",
+                redirectUri = "https://client.example.com/callback",
+                codeVerifier = "code-verifier",
+            )
+        } returns OAuthTokenResult(accessToken = "oauth-access-token", refreshToken = null, expiresIn = 3600)
+        every { oAuthPort.getUserInfo("oauth-access-token") } returns oAuthUserInfo
+    }
+
+    private fun studentOAuthUserInfo(): OAuthUserInfo =
+        OAuthUserInfo(
+            email = "student@gsm.hs.kr",
+            isStudent = true,
+            name = "학생",
+            grade = 2,
+            classNum = 3,
+            number = 4,
+        )
+
+    private fun studentUser(): User =
+        User(
+            userId = 1,
+            userName = "학생",
+            userEmail = "student@gsm.hs.kr",
+            userGrade = 2,
+            userClassNumber = 3,
+            userNumber = 4,
+            userRole = UserRole.STUDENT,
+        )
+}

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
@@ -1,16 +1,14 @@
 package team.incube.gsmc.domain.auth.service
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import team.incube.gsmc.domain.auth.port.out.AuthTokenPort
 import team.incube.gsmc.domain.auth.port.out.RefreshTokenPersistencePort
 import team.incube.gsmc.domain.auth.port.out.UserPersistencePort
@@ -19,116 +17,20 @@ import team.incube.gsmc.domain.user.UserRole
 import team.incube.gsmc.global.exception.ErrorCode
 import team.incube.gsmc.global.exception.GsmcException
 
-@DisplayName("RefreshTokenService")
-class RefreshTokenServiceTest {
-    private val authTokenPort = mockk<AuthTokenPort>()
-    private val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
-    private val userPersistencePort = mockk<UserPersistencePort>()
-    private val refreshTokenService =
+class RefreshTokenServiceTest : BehaviorSpec({
+    val authTokenPort = mockk<AuthTokenPort>()
+    val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+    val userPersistencePort = mockk<UserPersistencePort>()
+    val refreshTokenService =
         RefreshTokenService(
             authTokenPort = authTokenPort,
             refreshTokenPersistencePort = refreshTokenPersistencePort,
             userPersistencePort = userPersistencePort,
         )
 
-    @Nested
-    @DisplayName("Given 유효한 리프레시 토큰이 주어졌을 때")
-    inner class GivenValidRefreshToken {
-        @Test
-        @DisplayName("When 토큰을 갱신하면 Then 새 토큰을 발급하고 저장한다")
-        fun `토큰을 갱신하면 새 토큰을 발급하고 저장한다`() {
-            val user = user()
+    beforeEach { clearAllMocks() }
 
-            every { authTokenPort.parseTokenClaims("refresh-token") } returns (user.userId to user.userRole)
-            every { refreshTokenPersistencePort.find(user.userId) } returns "refresh-token"
-            every { userPersistencePort.findByUserId(user.userId) } returns user
-            every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "new-access-token"
-            every { authTokenPort.generateRefreshToken(user.userId) } returns "new-refresh-token"
-            every { authTokenPort.accessTokenExpiresIn } returns 3600
-            every { authTokenPort.refreshTokenExpiresIn } returns 7200
-            every { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") } just runs
-
-            val before = System.currentTimeMillis()
-            val result = refreshTokenService.execute("refresh-token")
-            val after = System.currentTimeMillis()
-
-            assertEquals("new-access-token", result.accessToken)
-            assertEquals("new-refresh-token", result.refreshToken)
-            assertEquals(UserRole.STUDENT, result.role)
-            assertTrue(result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000))
-            assertTrue(result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000))
-            verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") }
-        }
-    }
-
-    @Nested
-    @DisplayName("Given 유효하지 않은 리프레시 토큰이 주어졌을 때")
-    inner class GivenInvalidRefreshToken {
-        @Test
-        @DisplayName("When 토큰 파싱에 실패하면 Then INVALID_REFRESH_TOKEN 예외가 발생한다")
-        fun `토큰 파싱에 실패하면 INVALID_REFRESH_TOKEN 예외가 발생한다`() {
-            every { authTokenPort.parseTokenClaims("invalid-token") } returns null
-
-            val exception =
-                assertThrows(GsmcException::class.java) {
-                    refreshTokenService.execute("invalid-token")
-                }
-
-            assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
-            verify(exactly = 0) { refreshTokenPersistencePort.find(any()) }
-        }
-
-        @Test
-        @DisplayName("When 저장된 토큰이 없으면 Then INVALID_REFRESH_TOKEN 예외가 발생한다")
-        fun `저장된 토큰이 없으면 INVALID_REFRESH_TOKEN 예외가 발생한다`() {
-            every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
-            every { refreshTokenPersistencePort.find(1L) } returns null
-
-            val exception =
-                assertThrows(GsmcException::class.java) {
-                    refreshTokenService.execute("refresh-token")
-                }
-
-            assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
-            verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
-        }
-
-        @Test
-        @DisplayName("When 저장된 토큰과 다르면 Then INVALID_REFRESH_TOKEN 예외가 발생한다")
-        fun `저장된 토큰과 다르면 INVALID_REFRESH_TOKEN 예외가 발생한다`() {
-            every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
-            every { refreshTokenPersistencePort.find(1L) } returns "other-refresh-token"
-
-            val exception =
-                assertThrows(GsmcException::class.java) {
-                    refreshTokenService.execute("refresh-token")
-                }
-
-            assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
-            verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
-        }
-    }
-
-    @Nested
-    @DisplayName("Given 토큰은 유효하지만 사용자가 없을 때")
-    inner class GivenMissingUser {
-        @Test
-        @DisplayName("When 토큰을 갱신하면 Then USER_NOT_FOUND 예외가 발생한다")
-        fun `토큰을 갱신하면 USER_NOT_FOUND 예외가 발생한다`() {
-            every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
-            every { refreshTokenPersistencePort.find(1L) } returns "refresh-token"
-            every { userPersistencePort.findByUserId(1L) } returns null
-
-            val exception =
-                assertThrows(GsmcException::class.java) {
-                    refreshTokenService.execute("refresh-token")
-                }
-
-            assertEquals(ErrorCode.USER_NOT_FOUND, exception.errorCode)
-        }
-    }
-
-    private fun user(): User =
+    fun user() =
         User(
             userId = 1,
             userName = "학생",
@@ -138,4 +40,96 @@ class RefreshTokenServiceTest {
             userNumber = 4,
             userRole = UserRole.STUDENT,
         )
-}
+
+    Given("유효한 리프레시 토큰이 주어졌을 때") {
+        When("토큰을 갱신하면") {
+            Then("새 토큰을 발급하고 저장한다") {
+                val user = user()
+
+                every { authTokenPort.parseTokenClaims("refresh-token") } returns (user.userId to user.userRole)
+                every { refreshTokenPersistencePort.find(user.userId) } returns "refresh-token"
+                every { userPersistencePort.findByUserId(user.userId) } returns user
+                every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "new-access-token"
+                every { authTokenPort.generateRefreshToken(user.userId) } returns "new-refresh-token"
+                every { authTokenPort.accessTokenExpiresIn } returns 3600
+                every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                every { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") } just runs
+
+                val before = System.currentTimeMillis()
+                val result = refreshTokenService.execute("refresh-token")
+                val after = System.currentTimeMillis()
+
+                result.accessToken shouldBe "new-access-token"
+                result.refreshToken shouldBe "new-refresh-token"
+                result.role shouldBe UserRole.STUDENT
+                (result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000)) shouldBe true
+                (result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000)) shouldBe true
+                verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") }
+            }
+        }
+    }
+
+    Given("유효하지 않은 리프레시 토큰이 주어졌을 때") {
+        When("토큰 파싱에 실패하면") {
+            Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
+                every { authTokenPort.parseTokenClaims("invalid-token") } returns null
+
+                val exception =
+                    shouldThrow<GsmcException> {
+                        refreshTokenService.execute("invalid-token")
+                    }
+
+                exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
+                verify(exactly = 0) { refreshTokenPersistencePort.find(any()) }
+                verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+            }
+        }
+
+        When("저장된 토큰이 없으면") {
+            Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
+                every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                every { refreshTokenPersistencePort.find(1L) } returns null
+
+                val exception =
+                    shouldThrow<GsmcException> {
+                        refreshTokenService.execute("refresh-token")
+                    }
+
+                exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
+                verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+            }
+        }
+
+        When("저장된 토큰과 다르면") {
+            Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
+                every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                every { refreshTokenPersistencePort.find(1L) } returns "other-refresh-token"
+
+                val exception =
+                    shouldThrow<GsmcException> {
+                        refreshTokenService.execute("refresh-token")
+                    }
+
+                exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
+                verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+            }
+        }
+    }
+
+    Given("토큰은 유효하지만 사용자가 없을 때") {
+        When("토큰을 갱신하면") {
+            Then("USER_NOT_FOUND 예외가 발생한다") {
+                every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                every { refreshTokenPersistencePort.find(1L) } returns "refresh-token"
+                every { userPersistencePort.findByUserId(1L) } returns null
+
+                val exception =
+                    shouldThrow<GsmcException> {
+                        refreshTokenService.execute("refresh-token")
+                    }
+
+                exception.errorCode shouldBe ErrorCode.USER_NOT_FOUND
+            }
+        }
+    }
+})

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
@@ -17,119 +17,120 @@ import team.incube.gsmc.domain.user.UserRole
 import team.incube.gsmc.global.exception.ErrorCode
 import team.incube.gsmc.global.exception.GsmcException
 
-class RefreshTokenServiceTest : BehaviorSpec({
-    val authTokenPort = mockk<AuthTokenPort>()
-    val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
-    val userPersistencePort = mockk<UserPersistencePort>()
-    val refreshTokenService =
-        RefreshTokenService(
-            authTokenPort = authTokenPort,
-            refreshTokenPersistencePort = refreshTokenPersistencePort,
-            userPersistencePort = userPersistencePort,
-        )
+class RefreshTokenServiceTest :
+    BehaviorSpec({
+        val authTokenPort = mockk<AuthTokenPort>()
+        val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+        val userPersistencePort = mockk<UserPersistencePort>()
+        val refreshTokenService =
+            RefreshTokenService(
+                authTokenPort = authTokenPort,
+                refreshTokenPersistencePort = refreshTokenPersistencePort,
+                userPersistencePort = userPersistencePort,
+            )
 
-    beforeEach { clearAllMocks() }
+        beforeEach { clearAllMocks() }
 
-    fun user() =
-        User(
-            userId = 1,
-            userName = "학생",
-            userEmail = "student@gsm.hs.kr",
-            userGrade = 2,
-            userClassNumber = 3,
-            userNumber = 4,
-            userRole = UserRole.STUDENT,
-        )
+        fun user() =
+            User(
+                userId = 1,
+                userName = "학생",
+                userEmail = "student@gsm.hs.kr",
+                userGrade = 2,
+                userClassNumber = 3,
+                userNumber = 4,
+                userRole = UserRole.STUDENT,
+            )
 
-    Given("유효한 리프레시 토큰이 주어졌을 때") {
-        When("토큰을 갱신하면") {
-            Then("새 토큰을 발급하고 저장한다") {
-                val user = user()
+        Given("유효한 리프레시 토큰이 주어졌을 때") {
+            When("토큰을 갱신하면") {
+                Then("새 토큰을 발급하고 저장한다") {
+                    val user = user()
 
-                every { authTokenPort.parseTokenClaims("refresh-token") } returns (user.userId to user.userRole)
-                every { refreshTokenPersistencePort.find(user.userId) } returns "refresh-token"
-                every { userPersistencePort.findByUserId(user.userId) } returns user
-                every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "new-access-token"
-                every { authTokenPort.generateRefreshToken(user.userId) } returns "new-refresh-token"
-                every { authTokenPort.accessTokenExpiresIn } returns 3600
-                every { authTokenPort.refreshTokenExpiresIn } returns 7200
-                every { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") } just runs
+                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (user.userId to user.userRole)
+                    every { refreshTokenPersistencePort.find(user.userId) } returns "refresh-token"
+                    every { userPersistencePort.findByUserId(user.userId) } returns user
+                    every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "new-access-token"
+                    every { authTokenPort.generateRefreshToken(user.userId) } returns "new-refresh-token"
+                    every { authTokenPort.accessTokenExpiresIn } returns 3600
+                    every { authTokenPort.refreshTokenExpiresIn } returns 7200
+                    every { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") } just runs
 
-                val before = System.currentTimeMillis()
-                val result = refreshTokenService.execute("refresh-token")
-                val after = System.currentTimeMillis()
+                    val before = System.currentTimeMillis()
+                    val result = refreshTokenService.execute("refresh-token")
+                    val after = System.currentTimeMillis()
 
-                result.accessToken shouldBe "new-access-token"
-                result.refreshToken shouldBe "new-refresh-token"
-                result.role shouldBe UserRole.STUDENT
-                (result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000)) shouldBe true
-                (result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000)) shouldBe true
-                verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") }
-            }
-        }
-    }
-
-    Given("유효하지 않은 리프레시 토큰이 주어졌을 때") {
-        When("토큰 파싱에 실패하면") {
-            Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                every { authTokenPort.parseTokenClaims("invalid-token") } returns null
-
-                val exception =
-                    shouldThrow<GsmcException> {
-                        refreshTokenService.execute("invalid-token")
-                    }
-
-                exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
-                verify(exactly = 0) { refreshTokenPersistencePort.find(any()) }
-                verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+                    result.accessToken shouldBe "new-access-token"
+                    result.refreshToken shouldBe "new-refresh-token"
+                    result.role shouldBe UserRole.STUDENT
+                    (result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000)) shouldBe true
+                    (result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000)) shouldBe true
+                    verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") }
+                }
             }
         }
 
-        When("저장된 토큰이 없으면") {
-            Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
-                every { refreshTokenPersistencePort.find(1L) } returns null
+        Given("유효하지 않은 리프레시 토큰이 주어졌을 때") {
+            When("토큰 파싱에 실패하면") {
+                Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
+                    every { authTokenPort.parseTokenClaims("invalid-token") } returns null
 
-                val exception =
-                    shouldThrow<GsmcException> {
-                        refreshTokenService.execute("refresh-token")
-                    }
+                    val exception =
+                        shouldThrow<GsmcException> {
+                            refreshTokenService.execute("invalid-token")
+                        }
 
-                exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
-                verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+                    exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
+                    verify(exactly = 0) { refreshTokenPersistencePort.find(any()) }
+                    verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+                }
+            }
+
+            When("저장된 토큰이 없으면") {
+                Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
+                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                    every { refreshTokenPersistencePort.find(1L) } returns null
+
+                    val exception =
+                        shouldThrow<GsmcException> {
+                            refreshTokenService.execute("refresh-token")
+                        }
+
+                    exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
+                    verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+                }
+            }
+
+            When("저장된 토큰과 다르면") {
+                Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
+                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                    every { refreshTokenPersistencePort.find(1L) } returns "other-refresh-token"
+
+                    val exception =
+                        shouldThrow<GsmcException> {
+                            refreshTokenService.execute("refresh-token")
+                        }
+
+                    exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
+                    verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+                }
             }
         }
 
-        When("저장된 토큰과 다르면") {
-            Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
-                every { refreshTokenPersistencePort.find(1L) } returns "other-refresh-token"
+        Given("토큰은 유효하지만 사용자가 없을 때") {
+            When("토큰을 갱신하면") {
+                Then("USER_NOT_FOUND 예외가 발생한다") {
+                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                    every { refreshTokenPersistencePort.find(1L) } returns "refresh-token"
+                    every { userPersistencePort.findByUserId(1L) } returns null
 
-                val exception =
-                    shouldThrow<GsmcException> {
-                        refreshTokenService.execute("refresh-token")
-                    }
+                    val exception =
+                        shouldThrow<GsmcException> {
+                            refreshTokenService.execute("refresh-token")
+                        }
 
-                exception.errorCode shouldBe ErrorCode.INVALID_REFRESH_TOKEN
-                verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
+                    exception.errorCode shouldBe ErrorCode.USER_NOT_FOUND
+                }
             }
         }
-    }
-
-    Given("토큰은 유효하지만 사용자가 없을 때") {
-        When("토큰을 갱신하면") {
-            Then("USER_NOT_FOUND 예외가 발생한다") {
-                every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
-                every { refreshTokenPersistencePort.find(1L) } returns "refresh-token"
-                every { userPersistencePort.findByUserId(1L) } returns null
-
-                val exception =
-                    shouldThrow<GsmcException> {
-                        refreshTokenService.execute("refresh-token")
-                    }
-
-                exception.errorCode shouldBe ErrorCode.USER_NOT_FOUND
-            }
-        }
-    }
-})
+    })

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
@@ -1,0 +1,137 @@
+package team.incube.gsmc.domain.auth.service
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import team.incube.gsmc.domain.auth.port.out.AuthTokenPort
+import team.incube.gsmc.domain.auth.port.out.RefreshTokenPersistencePort
+import team.incube.gsmc.domain.auth.port.out.UserPersistencePort
+import team.incube.gsmc.domain.user.User
+import team.incube.gsmc.domain.user.UserRole
+import team.incube.gsmc.global.exception.ErrorCode
+import team.incube.gsmc.global.exception.GsmcException
+
+@DisplayName("RefreshTokenService")
+class RefreshTokenServiceTest {
+    private val authTokenPort = mockk<AuthTokenPort>()
+    private val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+    private val userPersistencePort = mockk<UserPersistencePort>()
+    private val refreshTokenService =
+        RefreshTokenService(
+            authTokenPort = authTokenPort,
+            refreshTokenPersistencePort = refreshTokenPersistencePort,
+            userPersistencePort = userPersistencePort,
+        )
+
+    @Nested
+    @DisplayName("Given 유효한 리프레시 토큰이 주어졌을 때")
+    inner class GivenValidRefreshToken {
+        @Test
+        @DisplayName("When 토큰을 갱신하면 Then 새 토큰을 발급하고 저장한다")
+        fun `토큰을 갱신하면 새 토큰을 발급하고 저장한다`() {
+            val user = user()
+
+            every { authTokenPort.parseTokenClaims("refresh-token") } returns (user.userId to user.userRole)
+            every { refreshTokenPersistencePort.find(user.userId) } returns "refresh-token"
+            every { userPersistencePort.findByUserId(user.userId) } returns user
+            every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "new-access-token"
+            every { authTokenPort.generateRefreshToken(user.userId) } returns "new-refresh-token"
+            every { authTokenPort.accessTokenExpiresIn } returns 3600
+            every { authTokenPort.refreshTokenExpiresIn } returns 7200
+            every { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") } just runs
+
+            val result = refreshTokenService.execute("refresh-token")
+
+            assertEquals("new-access-token", result.accessToken)
+            assertEquals("new-refresh-token", result.refreshToken)
+            assertEquals(UserRole.STUDENT, result.role)
+            assertTrue(result.accessTokenExpiresIn > System.currentTimeMillis())
+            assertTrue(result.refreshTokenExpiresIn > result.accessTokenExpiresIn)
+            verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") }
+        }
+    }
+
+    @Nested
+    @DisplayName("Given 유효하지 않은 리프레시 토큰이 주어졌을 때")
+    inner class GivenInvalidRefreshToken {
+        @Test
+        @DisplayName("When 토큰 파싱에 실패하면 Then INVALID_REFRESH_TOKEN 예외가 발생한다")
+        fun `토큰 파싱에 실패하면 INVALID_REFRESH_TOKEN 예외가 발생한다`() {
+            every { authTokenPort.parseTokenClaims("invalid-token") } returns null
+
+            val exception =
+                assertThrows(GsmcException::class.java) {
+                    refreshTokenService.execute("invalid-token")
+                }
+
+            assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
+            verify(exactly = 0) { refreshTokenPersistencePort.find(any()) }
+        }
+
+        @Test
+        @DisplayName("When 저장된 토큰이 없으면 Then INVALID_REFRESH_TOKEN 예외가 발생한다")
+        fun `저장된 토큰이 없으면 INVALID_REFRESH_TOKEN 예외가 발생한다`() {
+            every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+            every { refreshTokenPersistencePort.find(1L) } returns null
+
+            val exception =
+                assertThrows(GsmcException::class.java) {
+                    refreshTokenService.execute("refresh-token")
+                }
+
+            assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("When 저장된 토큰과 다르면 Then INVALID_REFRESH_TOKEN 예외가 발생한다")
+        fun `저장된 토큰과 다르면 INVALID_REFRESH_TOKEN 예외가 발생한다`() {
+            every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+            every { refreshTokenPersistencePort.find(1L) } returns "other-refresh-token"
+
+            val exception =
+                assertThrows(GsmcException::class.java) {
+                    refreshTokenService.execute("refresh-token")
+                }
+
+            assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("Given 토큰은 유효하지만 사용자가 없을 때")
+    inner class GivenMissingUser {
+        @Test
+        @DisplayName("When 토큰을 갱신하면 Then USER_NOT_FOUND 예외가 발생한다")
+        fun `토큰을 갱신하면 USER_NOT_FOUND 예외가 발생한다`() {
+            every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+            every { refreshTokenPersistencePort.find(1L) } returns "refresh-token"
+            every { userPersistencePort.findByUserId(1L) } returns null
+
+            val exception =
+                assertThrows(GsmcException::class.java) {
+                    refreshTokenService.execute("refresh-token")
+                }
+
+            assertEquals(ErrorCode.USER_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    private fun user(): User =
+        User(
+            userId = 1,
+            userName = "학생",
+            userEmail = "student@gsm.hs.kr",
+            userGrade = 2,
+            userClassNumber = 3,
+            userNumber = 4,
+            userRole = UserRole.STUDENT,
+        )
+}

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
@@ -48,13 +48,15 @@ class RefreshTokenServiceTest {
             every { authTokenPort.refreshTokenExpiresIn } returns 7200
             every { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") } just runs
 
+            val before = System.currentTimeMillis()
             val result = refreshTokenService.execute("refresh-token")
+            val after = System.currentTimeMillis()
 
             assertEquals("new-access-token", result.accessToken)
             assertEquals("new-refresh-token", result.refreshToken)
             assertEquals(UserRole.STUDENT, result.role)
-            assertTrue(result.accessTokenExpiresIn > System.currentTimeMillis())
-            assertTrue(result.refreshTokenExpiresIn > result.accessTokenExpiresIn)
+            assertTrue(result.accessTokenExpiresIn in (before + 3600 * 1000)..(after + 3600 * 1000))
+            assertTrue(result.refreshTokenExpiresIn in (before + 7200 * 1000)..(after + 7200 * 1000))
             verify(exactly = 1) { refreshTokenPersistencePort.save(user.userId, "new-refresh-token") }
         }
     }
@@ -88,6 +90,7 @@ class RefreshTokenServiceTest {
                 }
 
             assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
+            verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
         }
 
         @Test
@@ -102,6 +105,7 @@ class RefreshTokenServiceTest {
                 }
 
             assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.errorCode)
+            verify(exactly = 0) { userPersistencePort.findByUserId(any()) }
         }
     }
 

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RemoveMyRefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RemoveMyRefreshTokenServiceTest.kt
@@ -10,27 +10,28 @@ import io.mockk.verify
 import team.incube.gsmc.domain.auth.port.out.RefreshTokenPersistencePort
 import team.incube.gsmc.global.util.MemberUtil
 
-class RemoveMyRefreshTokenServiceTest : BehaviorSpec({
-    val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
-    val memberUtil = mockk<MemberUtil>()
-    val removeMyRefreshTokenService =
-        RemoveMyRefreshTokenService(
-            refreshTokenPersistencePort = refreshTokenPersistencePort,
-            memberUtil = memberUtil,
-        )
+class RemoveMyRefreshTokenServiceTest :
+    BehaviorSpec({
+        val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+        val memberUtil = mockk<MemberUtil>()
+        val removeMyRefreshTokenService =
+            RemoveMyRefreshTokenService(
+                refreshTokenPersistencePort = refreshTokenPersistencePort,
+                memberUtil = memberUtil,
+            )
 
-    beforeEach { clearAllMocks() }
+        beforeEach { clearAllMocks() }
 
-    Given("인증된 사용자가 있을 때") {
-        When("로그아웃하면") {
-            Then("현재 사용자의 리프레시 토큰을 삭제한다") {
-                every { memberUtil.getCurrentUserId() } returns 1L
-                every { refreshTokenPersistencePort.delete(1L) } just runs
+        Given("인증된 사용자가 있을 때") {
+            When("로그아웃하면") {
+                Then("현재 사용자의 리프레시 토큰을 삭제한다") {
+                    every { memberUtil.getCurrentUserId() } returns 1L
+                    every { refreshTokenPersistencePort.delete(1L) } just runs
 
-                removeMyRefreshTokenService.execute()
+                    removeMyRefreshTokenService.execute()
 
-                verify(exactly = 1) { refreshTokenPersistencePort.delete(1L) }
+                    verify(exactly = 1) { refreshTokenPersistencePort.delete(1L) }
+                }
             }
         }
-    }
-})
+    })

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RemoveMyRefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RemoveMyRefreshTokenServiceTest.kt
@@ -1,38 +1,36 @@
 package team.incube.gsmc.domain.auth.service
 
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import team.incube.gsmc.domain.auth.port.out.RefreshTokenPersistencePort
 import team.incube.gsmc.global.util.MemberUtil
 
-@DisplayName("RemoveMyRefreshTokenService")
-class RemoveMyRefreshTokenServiceTest {
-    private val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
-    private val memberUtil = mockk<MemberUtil>()
-    private val removeMyRefreshTokenService =
+class RemoveMyRefreshTokenServiceTest : BehaviorSpec({
+    val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+    val memberUtil = mockk<MemberUtil>()
+    val removeMyRefreshTokenService =
         RemoveMyRefreshTokenService(
             refreshTokenPersistencePort = refreshTokenPersistencePort,
             memberUtil = memberUtil,
         )
 
-    @Nested
-    @DisplayName("Given 인증된 사용자가 있을 때")
-    inner class GivenAuthenticatedUser {
-        @Test
-        @DisplayName("When 로그아웃하면 Then 현재 사용자의 리프레시 토큰을 삭제한다")
-        fun `로그아웃하면 현재 사용자의 리프레시 토큰을 삭제한다`() {
-            every { memberUtil.getCurrentUserId() } returns 1L
-            every { refreshTokenPersistencePort.delete(1L) } just runs
+    beforeEach { clearAllMocks() }
 
-            removeMyRefreshTokenService.execute()
+    Given("인증된 사용자가 있을 때") {
+        When("로그아웃하면") {
+            Then("현재 사용자의 리프레시 토큰을 삭제한다") {
+                every { memberUtil.getCurrentUserId() } returns 1L
+                every { refreshTokenPersistencePort.delete(1L) } just runs
 
-            verify(exactly = 1) { refreshTokenPersistencePort.delete(1L) }
+                removeMyRefreshTokenService.execute()
+
+                verify(exactly = 1) { refreshTokenPersistencePort.delete(1L) }
+            }
         }
     }
-}
+})

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RemoveMyRefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RemoveMyRefreshTokenServiceTest.kt
@@ -1,0 +1,38 @@
+package team.incube.gsmc.domain.auth.service
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import team.incube.gsmc.domain.auth.port.out.RefreshTokenPersistencePort
+import team.incube.gsmc.global.util.MemberUtil
+
+@DisplayName("RemoveMyRefreshTokenService")
+class RemoveMyRefreshTokenServiceTest {
+    private val refreshTokenPersistencePort = mockk<RefreshTokenPersistencePort>()
+    private val memberUtil = mockk<MemberUtil>()
+    private val removeMyRefreshTokenService =
+        RemoveMyRefreshTokenService(
+            refreshTokenPersistencePort = refreshTokenPersistencePort,
+            memberUtil = memberUtil,
+        )
+
+    @Nested
+    @DisplayName("Given 인증된 사용자가 있을 때")
+    inner class GivenAuthenticatedUser {
+        @Test
+        @DisplayName("When 로그아웃하면 Then 현재 사용자의 리프레시 토큰을 삭제한다")
+        fun `로그아웃하면 현재 사용자의 리프레시 토큰을 삭제한다`() {
+            every { memberUtil.getCurrentUserId() } returns 1L
+            every { refreshTokenPersistencePort.delete(1L) } just runs
+
+            removeMyRefreshTokenService.execute()
+
+            verify(exactly = 1) { refreshTokenPersistencePort.delete(1L) }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
auth 도메인 서비스 레이어의 단위 테스트를 추가하였습니다. MockK 라이브러리를 도입하여 의존성을 모킹하고, 각 서비스의 핵심 로직을 검증하는 테스트를 작성하였습니다.

## 변경 사항
- MockK 테스트 의존성을 추가하였습니다. (`io.mockk:mockk:1.14.6`)
- `FetchAuthorizationUrlServiceTest`: OAuth 인가 URL 생성 시 state 저장 및 URL 반환 로직을 검증하였습니다.
- `LoginServiceTest`: 기존 사용자 로그인, 신규 학생/교사 가입 후 로그인, 유효하지 않은 state에 대한 예외 처리를 검증하였습니다.
- `RefreshTokenServiceTest`: 리프레시 토큰 갱신 성공 및 토큰 파싱 실패, 저장된 토큰 없음, 토큰 불일치, 사용자 없음 등 실패 케이스를 검증하였습니다.
- `RemoveMyRefreshTokenServiceTest`: 로그아웃 시 현재 사용자의 리프레시 토큰이 삭제되는지 검증하였습니다.

## 참고 사항
`LoginService`는 내부적으로 `PlatformTransactionManager`를 직접 주입받아 트랜잭션을 관리하므로, 테스트에서 `transactionManager`를 모킹하였습니다. 모든 테스트는 Given-When-Then 패턴을 따릅니다.

## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [ ] PR의 올바른 라벨과 리뷰어를 설정했나요?

### 관련 이슈