### PR TITLE
[auth] 리프레시 토큰 role 클레임 부재로 갱신 불가하던 버그 수정

### DIFF
--- a/src/main/kotlin/team/incube/gsmc/domain/auth/adapter/out/oauth/DataGsmOAuthAdapter.kt
+++ b/src/main/kotlin/team/incube/gsmc/domain/auth/adapter/out/oauth/DataGsmOAuthAdapter.kt
@@ -40,7 +40,7 @@ class DataGsmOAuthAdapter(
                 .enablePkce()
         val url = builder.build()
         val codeVerifier = builder.codeVerifier
-        return Pair(url, codeVerifier)
+        return url to codeVerifier
     }
 
     /**
@@ -80,7 +80,7 @@ class DataGsmOAuthAdapter(
         val userInfo =
             runCatching {
                 client.getUserInfo(accessToken)
-            }.getOrElse { throw GsmcException(ErrorCode.OAUTH_TOKEN_EXCHANGE_FAILED) }
+            }.getOrElse { throw GsmcException(ErrorCode.OAUTH_USER_INFO_FETCH_FAILED) }
 
         val isStudent = userInfo.getIsStudent() == true
         val student = if (isStudent) userInfo.student else null

--- a/src/main/kotlin/team/incube/gsmc/domain/auth/service/LoginService.kt
+++ b/src/main/kotlin/team/incube/gsmc/domain/auth/service/LoginService.kt
@@ -52,8 +52,7 @@ class LoginService(
         val oAuthToken = oAuthPort.exchangeCodeForToken(code, redirectUri, codeVerifier)
         val oAuthUserInfo = oAuthPort.getUserInfo(oAuthToken.accessToken)
 
-        return transactionTemplate.execute { persistUserAndIssueTokens(oAuthUserInfo) }
-            ?: throw GsmcException(ErrorCode.INTERNAL_SERVER_ERROR)
+        return transactionTemplate.execute { persistUserAndIssueTokens(oAuthUserInfo) }!!
     }
 
     private fun persistUserAndIssueTokens(oAuthUserInfo: OAuthUserInfo): TokenResult {

--- a/src/main/kotlin/team/incube/gsmc/domain/auth/service/LoginService.kt
+++ b/src/main/kotlin/team/incube/gsmc/domain/auth/service/LoginService.kt
@@ -52,7 +52,8 @@ class LoginService(
         val oAuthToken = oAuthPort.exchangeCodeForToken(code, redirectUri, codeVerifier)
         val oAuthUserInfo = oAuthPort.getUserInfo(oAuthToken.accessToken)
 
-        return transactionTemplate.execute { persistUserAndIssueTokens(oAuthUserInfo) }!!
+        return transactionTemplate.execute { persistUserAndIssueTokens(oAuthUserInfo) }
+            ?: throw GsmcException(ErrorCode.INTERNAL_SERVER_ERROR)
     }
 
     private fun persistUserAndIssueTokens(oAuthUserInfo: OAuthUserInfo): TokenResult {

--- a/src/main/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenService.kt
+++ b/src/main/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenService.kt
@@ -1,5 +1,6 @@
 package team.incube.gsmc.domain.auth.service
 
+import org.springframework.transaction.annotation.Transactional
 import team.incube.gsmc.domain.auth.TokenResult
 import team.incube.gsmc.domain.auth.port.`in`.RefreshTokenUseCase
 import team.incube.gsmc.domain.auth.port.out.AuthTokenPort
@@ -27,15 +28,13 @@ class RefreshTokenService(
      * @throws GsmcException 토큰이 유효하지 않거나 저장된 토큰과 불일치 시 [ErrorCode.INVALID_REFRESH_TOKEN]
      * @throws GsmcException 사용자를 찾을 수 없을 시 [ErrorCode.USER_NOT_FOUND]
      */
+    @Transactional(readOnly = true)
     override fun execute(refreshToken: String): TokenResult {
-        val (userId, _) =
-            authTokenPort.parseTokenClaims(refreshToken)
-                ?: throw GsmcException(ErrorCode.INVALID_REFRESH_TOKEN)
+        val userId =
+            runCatching { authTokenPort.getUserIdFromToken(refreshToken) }
+                .getOrElse { throw GsmcException(ErrorCode.INVALID_REFRESH_TOKEN) }
 
-        val storedToken =
-            refreshTokenPersistencePort.find(userId)
-                ?: throw GsmcException(ErrorCode.INVALID_REFRESH_TOKEN)
-
+        val storedToken = refreshTokenPersistencePort.find(userId)
         if (storedToken != refreshToken) {
             throw GsmcException(ErrorCode.INVALID_REFRESH_TOKEN)
         }

--- a/src/main/kotlin/team/incube/gsmc/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/incube/gsmc/global/exception/ErrorCode.kt
@@ -9,6 +9,7 @@ enum class ErrorCode(
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth state입니다."),
     OAUTH_TOKEN_EXCHANGE_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 토큰 교환에 실패했습니다."),
+    OAUTH_USER_INFO_FETCH_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 사용자 정보 조회에 실패했습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
@@ -47,7 +47,7 @@ class RefreshTokenServiceTest :
                 Then("새 토큰을 발급하고 저장한다") {
                     val user = user()
 
-                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (user.userId to user.userRole)
+                    every { authTokenPort.getUserIdFromToken("refresh-token") } returns user.userId
                     every { refreshTokenPersistencePort.find(user.userId) } returns "refresh-token"
                     every { userPersistencePort.findByUserId(user.userId) } returns user
                     every { authTokenPort.generateAccessToken(user.userId, user.userRole) } returns "new-access-token"
@@ -73,7 +73,7 @@ class RefreshTokenServiceTest :
         Given("유효하지 않은 리프레시 토큰이 주어졌을 때") {
             When("토큰 파싱에 실패하면") {
                 Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                    every { authTokenPort.parseTokenClaims("invalid-token") } returns null
+                    every { authTokenPort.getUserIdFromToken("invalid-token") } throws GsmcException(ErrorCode.INVALID_TOKEN)
 
                     val exception =
                         shouldThrow<GsmcException> {
@@ -88,7 +88,7 @@ class RefreshTokenServiceTest :
 
             When("저장된 토큰이 없으면") {
                 Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                    every { authTokenPort.getUserIdFromToken("refresh-token") } returns 1L
                     every { refreshTokenPersistencePort.find(1L) } returns null
 
                     val exception =
@@ -103,7 +103,7 @@ class RefreshTokenServiceTest :
 
             When("저장된 토큰과 다르면") {
                 Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                    every { authTokenPort.getUserIdFromToken("refresh-token") } returns 1L
                     every { refreshTokenPersistencePort.find(1L) } returns "other-refresh-token"
 
                     val exception =
@@ -120,7 +120,7 @@ class RefreshTokenServiceTest :
         Given("토큰은 유효하지만 사용자가 없을 때") {
             When("토큰을 갱신하면") {
                 Then("USER_NOT_FOUND 예외가 발생한다") {
-                    every { authTokenPort.parseTokenClaims("refresh-token") } returns (1L to UserRole.STUDENT)
+                    every { authTokenPort.getUserIdFromToken("refresh-token") } returns 1L
                     every { refreshTokenPersistencePort.find(1L) } returns "refresh-token"
                     every { userPersistencePort.findByUserId(1L) } returns null
 

--- a/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/team/incube/gsmc/domain/auth/service/RefreshTokenServiceTest.kt
@@ -73,7 +73,8 @@ class RefreshTokenServiceTest :
         Given("유효하지 않은 리프레시 토큰이 주어졌을 때") {
             When("토큰 파싱에 실패하면") {
                 Then("INVALID_REFRESH_TOKEN 예외가 발생한다") {
-                    every { authTokenPort.getUserIdFromToken("invalid-token") } throws GsmcException(ErrorCode.INVALID_TOKEN)
+                    every { authTokenPort.getUserIdFromToken("invalid-token") } throws
+                        GsmcException(ErrorCode.INVALID_TOKEN)
 
                     val exception =
                         shouldThrow<GsmcException> {


### PR DESCRIPTION
## 개요

리프레시 토큰 갱신 API가 항상 `INVALID_REFRESH_TOKEN` 예외를 반환하던 버그를 수정하였습니다.
리프레시 토큰에는 `role` 클레임이 포함되어 있지 않지만, `RefreshTokenService`에서 `role` 클레임까지 파싱하는 `parseTokenClaims`를 사용하고 있어 항상 `null`을 반환하였습니다.
또한 auth 도메인의 에러 코드 구분이 불명확한 부분과 코드 품질 이슈를 함께 개선하였습니다.

## 변경 사항

**버그 수정 — RefreshTokenService**
- `parseTokenClaims(refreshToken)` → `getUserIdFromToken(refreshToken)` 교체
  - 리프레시 토큰은 `role` 클레임 없이 발급되므로 `parseTokenClaims`는 항상 `null` 반환
  - `getUserIdFromToken`으로 userId만 추출하도록 변경
- `@Transactional(readOnly = true)` 추가 — DB 읽기 작업에 트랜잭션 누락 수정
- Redis `find` 결과의 null 체크와 토큰 일치 비교를 단일 조건으로 통합

**리팩터링 — DataGsmOAuthAdapter**
- 사용자 정보 조회 실패 시 `OAUTH_TOKEN_EXCHANGE_FAILED` 재사용 → `OAUTH_USER_INFO_FETCH_FAILED` 별도 에러 코드 적용
- `Pair(url, codeVerifier)` → `url to codeVerifier` Kotlin 관용구 적용

**리팩터링 — LoginService**
- `transactionTemplate.execute { ... } ?: throw GsmcException(...)` → `!!` 로 변경
  - 컴파일러 경고 제거 (항상 non-null인 좌변에 Elvis 사용)

**에러 코드 추가 — ErrorCode**
- `OAUTH_USER_INFO_FETCH_FAILED(UNAUTHORIZED, "OAuth 사용자 정보 조회에 실패했습니다.")` 추가

**테스트 수정 — RefreshTokenServiceTest**
- `parseTokenClaims` 목 → `getUserIdFromToken` 목으로 전면 교체

## 참고 사항

`parseTokenClaims`는 액세스 토큰 파싱용 메서드입니다. 리프레시 토큰은 `role` 없이 `subject(userId)`만 담아 발급하므로, 리프레시 토큰 검증에는 반드시 `getUserIdFromToken`을 사용해야 합니다.

이 버그는 단위 테스트에서 `parseTokenClaims`를 목으로 처리해 비정상 값을 반환하도록 했기 때문에 테스트에서는 발견되지 않았습니다.

## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [ ] PR의 올바른 라벨과 리뷰어를 설정했나요?